### PR TITLE
ci: preserve Git safe-directory configuration

### DIFF
--- a/.github/workflows/commit-smoke-full.yml
+++ b/.github/workflows/commit-smoke-full.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Configure Git
         run: |
           set -eu
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/unifrog-gitconfig"
           git config --global --add safe.directory "$PWD"
           git config --global user.name "UniFrog CI"
           git config --global user.email "ci@unifrog.local"
-          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/unifrog-gitconfig"
           git config --global \
             url."https://github.com/axgdev/frog2k-qpsx.git".insteadOf \
             "git@github.com:axgdev/frog2k-qpsx.git"

--- a/.github/workflows/commit-smoke.yml
+++ b/.github/workflows/commit-smoke.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Configure Git
         run: |
           set -eu
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/unifrog-gitconfig"
           git config --global --add safe.directory "$PWD"
           git config --global user.name "UniFrog CI"
           git config --global user.email "ci@unifrog.local"
-          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/unifrog-gitconfig"
           git config --global \
             url."https://github.com/axgdev/frog2k-qpsx.git".insteadOf \
             "git@github.com:axgdev/frog2k-qpsx.git"

--- a/.github/workflows/sdcard-zip.yml
+++ b/.github/workflows/sdcard-zip.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Configure Git
         run: |
           set -eu
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/unifrog-gitconfig"
           git config --global --add safe.directory "$PWD"
           git config --global user.name "UniFrog CI"
           git config --global user.email "ci@unifrog.local"
-          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/unifrog-gitconfig"
           git config --global \
             url."https://github.com/axgdev/frog2k-qpsx.git".insteadOf \
             "git@github.com:axgdev/frog2k-qpsx.git"


### PR DESCRIPTION
Initialize GIT_CONFIG_GLOBAL before writing the safe.directory exception and URL rewrites. The previous order wrote safe.directory to Git's default global config, then switched to a new workflow-local config; subsequent git rev-parse in the container therefore reported /__w/UniFrog/UniFrog as dubious ownership.\n\nApply the ordering fix to the release SD-card workflow and both commit-smoke workflows because all three configure Git the same way. Keep the ref check strict: Verify build ref still compares the checked-out HEAD with GITHUB_SHA.\n\nEvidence: the exact failure was reproduced with a temporary repository owned by UID 65534; the corrected workflow-local config made git rev-parse succeed, and workflow order/diff checks passed. Risk: only Git configuration initialization changes; no build or release behavior is relaxed. Rollback: revert this commit to restore the previous configuration order.